### PR TITLE
Basic vagrant setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 !cwod_site/settings.py
 local_settings.py
 .DS_Store
+host/.vagrant
+

--- a/cwod_site/requirements.txt
+++ b/cwod_site/requirements.txt
@@ -15,7 +15,7 @@ django-piston==0.2.3
 django-typogrify==1.2.2
 gunicorn
 httplib2
-ipython==0.10.1
+ipython
 lxml==2.3
 mimeparse==0.1.3
 markdown
@@ -26,5 +26,3 @@ numpy==1.8.0
 python-dateutil==1.5
 python-memcached
 python-sunlightapi==1.0.0
-
-

--- a/host/Vagrantfile
+++ b/host/Vagrantfile
@@ -1,0 +1,107 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "../", "/cwod"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+      vb.memory = "2048"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+
+  # Install system level requirements and setup mysql
+  config.vm.provision "shell", inline: <<-SHELL
+     debconf-set-selections <<< 'mysql-server mysql-server/root_password password SuperPowers'
+     debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password SuperPowers'
+     apt-get update
+     apt-get -y install python-support python-dev python-pip openjdk-7-jdk mysql-server-5.6 mysql-client-5.6 solr-common libsolr-java python-pysolr libmysqlclient-dev mercurial-common git libxml2-dev libxslt1-dev
+
+     pip install virtualenvwrapper
+
+
+     # make dbs
+     if [ ! -f /var/log/databasesetup ];
+     then
+       echo "CREATE USER 'capitolwords'@'localhost' IDENTIFIED BY 'capitolwords'" | mysql -uroot -pSuperPowers
+       echo "CREATE DATABASE capitolwords" | mysql -uroot -pSuperPowers
+       echo "GRANT ALL ON capitolwords.* TO 'capitolwords'@'localhost'" | mysql -uroot -pSuperPowers
+       echo "flush privileges" | mysql -uroot -pSuperPowers
+
+       touch /var/log/databasesetup
+
+       if [ -f /vagrant/data/initial.sql ];
+         then
+           mysql -uroot -prootpass wordpress < /vagrant/data/initial.sql
+       fi
+     fi
+  SHELL
+
+  # Setup for virtualenv and any vagrant user environment stuff
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+     # set up env
+     pip install setuptools
+     source /usr/local/bin/virtualenvwrapper.sh
+     mkvirtualenv capitolwords
+     workon capitolwords
+     echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
+     cd /cwod/cwod_site
+     pip install -r requirements.txt
+     cp local_settings.example.py local_settings.py
+  SHELL
+end


### PR DESCRIPTION
This is a vagrantfile for a basic capitolwords vm.

Currently it installs:

- mysql with capitolwords user/db
- solr (I haven't actually tested this yet
- virtualenv with capitolwords environment setup from requirements.py
- mounts local repo at /cwod

I tried running python manage.py and got an error, but this is a good starting point.

To run this:

```
cd host
vagrant up
vagrant provision
vagrant ssh
workon capitolwords
cd /cwod/cwod_site
```

mysql

`mysql -D capitolwords -u capitolwords -p 
`(password is the same)

@wesc @ackramer @jeiranj not sure why i can't tag will or manny
