### PR TITLE
Replace NYT Congress API with ProPublica for import_roles command

### DIFF
--- a/cwod_site/bioguide/management/commands/import_bioguide.py
+++ b/cwod_site/bioguide/management/commands/import_bioguide.py
@@ -6,7 +6,7 @@ from optparse import make_option
 from django.core.management.base import BaseCommand, CommandError
 from django.db.utils import IntegrityError
 
-from bioguide.models import Legislator
+from cwod_site.bioguide.models import Legislator
 
 import name_tools
 from BeautifulSoup import BeautifulSoup

--- a/cwod_site/bioguide/management/commands/import_roles.py
+++ b/cwod_site/bioguide/management/commands/import_roles.py
@@ -1,13 +1,12 @@
-import json
 import time
-import urllib2
 
-from django.core.management.base import BaseCommand, CommandError
+import requests
+
+from django.core.management.base import BaseCommand
 from django.db.utils import IntegrityError
 from django.conf import settings
 
-from bioguide.models import *
-
+from cwod_site.bioguide.models import Legislator, LegislatorRole
 
 class Command(BaseCommand):
 
@@ -17,23 +16,28 @@ class Command(BaseCommand):
         except IndexError:
             congress = None
         bioguide_ids = Legislator.objects.order_by('bioguide_id').values_list('bioguide_id', flat=True).distinct()
+
+        s = requests.Session()
+        s.headers.update({'X-API-Key': settings.PROPUBLICA_API_KEY})
         for bioguide_id in bioguide_ids:
             # if LegislatorRole.objects.filter(bioguide_id=bioguide_id).count() > 0:
             #     continue
 
-            url = 'http://api.nytimes.com/svc/politics/v3/us/legislative/congress/members/%s.json?api-key=%s' % (bioguide_id, settings.NYT_API_KEY)
+            url = 'https://api.propublica.org/congress/v1/members/{}.json'.format(bioguide_id)
             try:
-                data = json.loads(urllib2.urlopen(url).read())
-            except urllib2.HTTPError:
-                print
-                print 'URL NOT FOUND FOR: %s' % bioguide_id
-                print
-                continue
+                data = s.get(url).json()
             except Exception, e:
                 print
                 print "CAUGHT ERROR FOR %s: %s" % (bioguide_id, e)
                 print
                 continue
+
+            if data['status'].upper() == 'ERROR':
+                print
+                print "API Responded with error for %s, %s" % (url, data['errors'])
+                print
+                continue
+
             result = data['results'][0]
             roles = result['roles']
             for role in roles:
@@ -57,5 +61,6 @@ class Command(BaseCommand):
                 except IntegrityError:
                     continue
 
-            time.sleep(.55)
+            time.sleep(0.1)
 
+        s.close()

--- a/cwod_site/bioguide/management/commands/import_roles.py
+++ b/cwod_site/bioguide/management/commands/import_roles.py
@@ -1,12 +1,12 @@
 import time
 
 import requests
-
 from django.core.management.base import BaseCommand
 from django.db.utils import IntegrityError
 from django.conf import settings
 
-from cwod_site.bioguide.models import Legislator, LegislatorRole
+from cwod_site.bioguide.models import Legislator
+from cwod_site.bioguide.models import LegislatorRole
 
 class Command(BaseCommand):
 
@@ -61,6 +61,6 @@ class Command(BaseCommand):
                 except IntegrityError:
                     continue
 
-            time.sleep(0.1)
+            time.sleep(0.5)
 
         s.close()

--- a/cwod_site/local_settings.example.py
+++ b/cwod_site/local_settings.example.py
@@ -15,7 +15,7 @@ TEMPLATE_DIRS = (
 	os.path.dirname(os.path.realpath(__file__)) + '/templates/'
 )
 
-NYT_API_KEY = ''
+PROPUBLICA_API_KEY = ''
 
 MEDIASYNC_AWS_KEY = ''
 MEDIASYNC_AWS_SECRET = ''

--- a/cwod_site/requirements.txt
+++ b/cwod_site/requirements.txt
@@ -26,3 +26,8 @@ numpy==1.8.0
 python-dateutil==1.5
 python-memcached
 python-sunlightapi==1.0.0
+ipdb
+requests==2.13.0
+pyopenssl==16.2.0
+ndg-httpsclient==0.4.2
+pyasn1==0.2.2

--- a/host/Vagrantfile
+++ b/host/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure(2) do |config|
      debconf-set-selections <<< 'mysql-server mysql-server/root_password password SuperPowers'
      debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password SuperPowers'
      apt-get update
-     apt-get -y install python-support python-dev python-pip openjdk-7-jdk mysql-server-5.6 mysql-client-5.6 solr-common libsolr-java python-pysolr libmysqlclient-dev mercurial-common git libxml2-dev libxslt1-dev
+     apt-get -y install python-support python-dev python-pip openjdk-7-jdk mysql-server-5.6 mysql-client-5.6 solr-common libsolr-java python-pysolr libmysqlclient-dev mercurial-common git libxml2-dev libxslt1-dev build-essential libssl-dev libffi-dev
 
      pip install virtualenvwrapper
 


### PR DESCRIPTION
Before daily_update.sh runs it looks like it depends on some bio data about legislators when running ingest.py (https://github.com/chartbeat-labs/Capitol-Words/blob/adrian_bioguide/solr/ingest.py#L241). This data needs to be initialized by running a few commands manually. Probably will want to figure out / ask when we ought to run this maybe should be part of a cron.

```
python manage.py syncdb

# reads from bioguide.congress.gov and adds data to the Legislator model
python manage.py import_bioguide [congress number e.g. 115]

# uses the data from Legislator model and ProPublica's congress API to create roles for those legislators
python manage.py import_roles [congress number e.g. 115]
```

import_roles would break as it was using an out of date NYTimes API that redirects to ProPublica but doesn't work because of API keys.

Anyway, this rips out the nytimes and uses ProPublica's API. Ran both manage.py commands and they work. Also makes SSL work correctly.

@will-horning @rmangi @manny 