### PR TITLE
Docker

### DIFF
--- a/cwod_site/Dockerfile.django
+++ b/cwod_site/Dockerfile.django
@@ -1,0 +1,8 @@
+FROM python:2.7
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /cwod_site
+WORKDIR /cwod_site
+ADD cwod_site /cwod_site
+RUN pip install -r requirements.txt
+RUN cp /cwod_site/local_settings_docker.py /cwod_site/local_settings.py
+EXPOSE 8000

--- a/cwod_site/local_settings_docker.py
+++ b/cwod_site/local_settings_docker.py
@@ -15,7 +15,8 @@ TEMPLATE_DIRS = (
 	os.path.dirname(os.path.realpath(__file__)) + '/templates/'
 )
 
-NYT_API_KEY = ''
+PROPUBLICA_API_KEY = ''
+SUNLIGHT_API_KEY = ""
 
 MEDIASYNC_AWS_KEY = ''
 MEDIASYNC_AWS_SECRET = ''
@@ -24,7 +25,6 @@ MEDIASYNC_AWS_PREFIX = ''
 MEDIASYNC_SERVE_REMOTE = False
 MEDIA_VERSION = ''
 
-SUNLIGHT_API_KEY = ""
 API_ROOT = "capitolwords.org/api"
 
 USE_LOCKSMITH = False

--- a/cwod_site/local_settings_docker.py
+++ b/cwod_site/local_settings_docker.py
@@ -1,0 +1,30 @@
+import os
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql', 		 # Add 'sqlite3', postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
+        'NAME': 'capitolwords',                      # Or path to database file if using sqlite3.
+        'USER': 'capitolwords',                      # Not used with sqlite3.
+        'PASSWORD': 'capitolwords',                  # Not used with sqlite3.
+        'HOST': 'db',                      	 # Set to empty string for localhost. Not used with sqlite3.
+        'PORT': '3306',                      	     # Set to empty string for default. Not used with sqlite3.
+    }
+}
+
+TEMPLATE_DIRS = (
+	os.path.dirname(os.path.realpath(__file__)) + '/templates/'
+)
+
+NYT_API_KEY = ''
+
+MEDIASYNC_AWS_KEY = ''
+MEDIASYNC_AWS_SECRET = ''
+MEDIASYNC_AWS_BUCKET = ''
+MEDIASYNC_AWS_PREFIX = ''
+MEDIASYNC_SERVE_REMOTE = False
+MEDIA_VERSION = ''
+
+SUNLIGHT_API_KEY = ""
+API_ROOT = "capitolwords.org/api"
+
+USE_LOCKSMITH = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '2'
+
+services:
+  solr:
+    image: solr
+    hostname: solr
+    ports:
+      - "8983:8983"
+    volumes:
+      - solr:/opt/solr/server/solr/mycores
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - mycore
+  db:
+    image: mysql:5.7
+    volumes:
+       - db_data:/var/lib/mysql
+    restart: always
+    environment:
+       MYSQL_ROOT_PASSWORD: superman
+       MYSQL_DATABASE: capitolwords
+       MYSQL_USER: capitolwords
+       MYSQL_PASSWORD: capitolwords
+  django:
+    build:
+      context: .
+      dockerfile: cwod_site/Dockerfile.django
+    command: python manage.py runserver --noreload 0.0.0.0:8000
+    ports:
+      - "8000:8000"
+    environment:
+      - CAPWORDS_BASEURL=http://localhost:8000
+      - CAPWORDS_HOME=/code
+      - CAPWORDS_TMP=/tmp
+      - CAPWORDS_LOGS=logs
+      - CAPWORDS_SOLR_URL=http://localhost:8983
+      - CAPWORDS_SUNLIGHT_APIKEY=foobar
+      - DJANGO_SETTINGS_MODULE=/code/settings.py
+    links:
+      - db
+      - solr
+
+volumes:
+  solr:
+  db_data:


### PR DESCRIPTION
Docker-Compose files for solr/django/mysql.

This is a standalone docker config for basically doing what we have with the Vagrant file directly on your mac. It spins up mysql, django and solr each in a separate container. 

To use this you need to install docker, get the latest stable osx version. Then:

`
docker-compose up
`

You should be able to hit the (broken) django app at 127.0.0.1:8000

I'm not sure about the workflow yet, being fairly new to docker. 

@wesc @butlern @manny @jeiranj @will-horning 